### PR TITLE
Run tests against Flutter main channel

### DIFF
--- a/.github/workflows/forui_build.yaml
+++ b/.github/workflows/forui_build.yaml
@@ -21,13 +21,19 @@ jobs:
       run:
         working-directory: forui
     strategy:
+      fail-fast: false
       matrix:
-        flutter-version: [ 3.x ]
+        include:
+          - flutter-version: 3.x
+            channel: stable
+          - flutter-version: ''
+            channel: main
     steps:
       - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2.23.0
         with:
           flutter-version: ${{ matrix.flutter-version }}
+          channel: ${{ matrix.channel }}
       - run: flutter pub get
       - run: dart run build_runner build
       - run: flutter analyze
@@ -51,6 +57,7 @@ jobs:
               exit 1
           fi
       - uses: codecov/codecov-action@v7
+        if: matrix.channel == 'stable'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/forui_build.yaml
+++ b/.github/workflows/forui_build.yaml
@@ -21,19 +21,13 @@ jobs:
       run:
         working-directory: forui
     strategy:
-      fail-fast: false
       matrix:
-        include:
-          - flutter-version: 3.x
-            channel: stable
-          - flutter-version: ''
-            channel: main
+        flutter-version: [ 3.x ]
     steps:
       - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2.23.0
         with:
           flutter-version: ${{ matrix.flutter-version }}
-          channel: ${{ matrix.channel }}
       - run: flutter pub get
       - run: dart run build_runner build
       - run: flutter analyze
@@ -57,9 +51,25 @@ jobs:
               exit 1
           fi
       - uses: codecov/codecov-action@v7
-        if: matrix.channel == 'stable'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-main:
+    name: Build & test (main channel)
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: forui
+    steps:
+      - uses: actions/checkout@v7
+      - uses: subosito/flutter-action@v2.23.0
+        with:
+          channel: main
+      - run: flutter pub get
+      - run: dart run build_runner build
+      - run: flutter analyze
+        continue-on-error: true
+      - run: flutter test --exclude-tags golden
 
   build-android:
     name: Build Android


### PR DESCRIPTION
**Describe the changes**
- Add a separate `test-main` job that runs tests against Flutter's main channel.
- `flutter analyze` in the main channel job is `continue-on-error` so analyzer issues don't fail CI.
- Skips coverage, doc checks, and goldens; stable `test` job is unchanged.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)