### PR TITLE
Add customer testing scripts for flutter/tests registry

### DIFF
--- a/customer_testing.bat
+++ b/customer_testing.bat
@@ -1,0 +1,12 @@
+@ECHO OFF
+REM This file is used by https://github.com/flutter/tests to run forui's tests as a presubmit for the flutter/flutter
+REM repository.
+REM Changes to this file (and any tests in this repository) are only honored after the commit hash in "forui.test" in
+REM that repository has been updated.
+REM Remember to also update the Posix version (customer_testing.sh) when changing this file.
+
+CD forui || EXIT /B 1
+CALL flutter pub get || EXIT /B 1
+CALL dart run build_runner build --delete-conflicting-outputs || EXIT /B 1
+CALL flutter analyze --no-fatal-infos || EXIT /B 1
+CALL flutter test --exclude-tags golden || EXIT /B 1

--- a/customer_testing.sh
+++ b/customer_testing.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# This file is used by https://github.com/flutter/tests to run forui's tests as a presubmit for the flutter/flutter
+# repository.
+# Changes to this file (and any tests in this repository) are only honored after the commit hash in "forui.test" in
+# that repository has been updated.
+# Remember to also update the Windows version (customer_testing.bat) when changing this file.
+
+set -e
+
+cd forui
+flutter pub get
+dart run build_runner build --delete-conflicting-outputs
+flutter analyze --no-fatal-infos
+flutter test --exclude-tags golden


### PR DESCRIPTION
**Describe the changes**
- Add `customer_testing.sh` / `customer_testing.bat` at the repo root, invoked by a future `forui.test` entry in [flutter/tests](https://github.com/flutter/tests) to run forui's tests as a presubmit for flutter/flutter.
- Scripts run `pub get`, `build_runner build` (`.design.dart` files are gitignored), `flutter analyze --no-fatal-infos`, and `flutter test --exclude-tags golden`.
- Follows the `flutter/packages` convention; the batch version propagates per-step failures via `EXIT /B 1`.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)