### PR TITLE
Stop pnpm release-age policy from failing Renovate lockfile updates

### DIFF
--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,4 +1,8 @@
 minimumReleaseAge: 4320 # 3 days
+# Setting minimumReleaseAge implicitly turns on minimumReleaseAgeStrict, which makes Renovate's lockfile update
+# (run with --no-save) fail outright when a transitive dependency is younger than the cutoff. Keep it off so the
+# cutoff only steers resolution towards aged versions.
+minimumReleaseAgeStrict: false
 allowBuilds:
   esbuild: true
   sharp: true


### PR DESCRIPTION
**Describe the changes**

- Set `minimumReleaseAgeStrict: false` in `docs/pnpm-workspace.yaml`.
- pnpm turns `minimumReleaseAgeStrict` on implicitly whenever `minimumReleaseAge` is set, so the 3 day cooldown added in
  #1064 also made the policy fatal.
- Renovate refreshes `docs/pnpm-lock.yaml` with `--no-save`, which strict mode rejects outright
  (`ERR_PNPM_STRICT_MIN_RELEASE_AGE_REQUIRES_SAVE`) whenever any resolved dependency is younger than the cutoff. The
  lockfile is left stale and `Build Docs & Snippets` then fails on `ERR_PNPM_OUTDATED_LOCKFILE`, as seen in #1182.
- Renovate's own `minimumReleaseAge: 5 days` only gates the direct versions it proposes, so a fresh transitive
  dependency can still trip the pnpm cutoff.
- With strict off, the cutoff still steers resolution towards aged versions (verified: `fumadocs-core: ^16.15.0` under a
  5 day cutoff resolves to `16.15.4`, not the 3 day old `16.15.7`); it just no longer aborts the install when an exact
  pin has no aged alternative.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4qgBC37KwyrCuB8Ka7fcb