### PR TITLE
Prepare to release Forui CLI 0.26.1

### DIFF
--- a/forui_cli/pubspec.yaml
+++ b/forui_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: forui_cli
 description: >-
   Command-line tool for Forui: create a theme and generate the styling boilerplate for your Forui app.
-version: 0.26.0
+version: 0.26.1
 homepage: https://forui.dev/
 documentation: https://forui.dev/docs
 repository: https://github.com/duobaseio/forui/tree/main/forui_cli


### PR DESCRIPTION
**Describe the changes**
* Bump `forui_cli` to `0.26.1`.
* Releases the fix for `forui theme create` generating incorrect `part of` directives on Windows (#1189).

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ch7VTYWgzPFcgiqRCXRd62